### PR TITLE
Added version command to print out version of the utility

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,35 @@
+// Copyright © 2018 Thomas Winsnes <twinsnes@live.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints out the current version",
+	Long:  `Prints out the current version of awscreds`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Version: 0.2-alpha")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
`awscreds version` will not print out the version of the utility

example:
```
$ awscreds version
Version: 0.2-alpha
```